### PR TITLE
Add docs for new partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ This might seem a lot of work when getting started, but for larger projects you 
 
 ### Placeholder Images
 
+You can use the `phImg` attribute to add placeholder images:
+```
+<img ph-img="230x400" />
+<img ph-img="230x400" text="asdf" bg-color="#aa0000" txt-color="#00f" />
+```
+
+It also works for background images:
+
+```
+<div ph-img="450x600" style="width: 450px; height: 600px">asdfasdasdf</div>
+```
+
+(Note that the size of the background image is independent of the size of the element)
+
 ### Placeholder Text
 
 ### Repeating Directive

--- a/README.md
+++ b/README.md
@@ -202,3 +202,8 @@ This results in the following markup in-browser:
 Note that text content outside your inner elements is not cloned. This means
 that if your contents consist entirely of inline elements, the cloned elements
 will not have spaces between them.
+
+
+### Pane directive
+
+### Tab directive

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ This might seem a lot of work when getting started, but for larger projects you 
 
 ### Placeholder Images
 
-You can use the `phImg` attribute to add placeholder images:
+You can use the `ph-img` attribute to add placeholder images:
+
 ```
 <img ph-img="230x400" />
 <img ph-img="230x400" text="asdf" bg-color="#aa0000" txt-color="#00f" />
@@ -158,6 +159,46 @@ It also works for background images:
 
 ### Placeholder Text
 
+The default is an element containing 3-7 paragraphs of 3-5 sentences each:
+```
+<ph-txt>
+```
+You can also get smaller amounts, and add it to other elements.
+
+``
+<div>
+  My text here. Followed by Lorem Ipsum. <ph-txt words=30>
+</div>
+```
+
+```
+<div ph-txt paragraphs=2 sentences=9>
+</div>
+```
+
 ### Repeating Directive
 
+Use `repeat=` to repeat the contents of an element. The new elements are created with jQuery's `.clone()` method.
 
+```
+<div repeat=3>
+  <h3>Hey there!</h3>
+  <div>This is my block content.</div>
+</div>
+```
+This results in the following markup in-browser:
+
+```
+<div repeat="3" class="ng-scope">
+  <h3>Hey there!</h3>
+  <div>This is my block content.</div>
+  <h3>Hey there!</h3>
+  <div>This is my block content.</div>
+  <h3>Hey there!</h3>
+  <div>This is my block content.</div>
+</div>
+```
+
+Note that text content outside your inner elements is not cloned. This means
+that if your contents consist entirely of inline elements, the cloned elements
+will not have spaces between them.

--- a/README.md
+++ b/README.md
@@ -144,14 +144,14 @@ This might seem a lot of work when getting started, but for larger projects you 
 
 You can use the `ph-img` attribute to add placeholder images:
 
-```
+```html
 <img ph-img="230x400" />
 <img ph-img="230x400" text="asdf" bg-color="#aa0000" txt-color="#00f" />
 ```
 
 It also works for background images:
 
-```
+```html
 <div ph-img="450x600" style="width: 450px; height: 600px">asdfasdasdf</div>
 ```
 
@@ -160,18 +160,19 @@ It also works for background images:
 ### Placeholder Text
 
 The default is an element containing 3-7 paragraphs of 3-5 sentences each:
-```
+
+```html
 <ph-txt>
 ```
 You can also get smaller amounts, and add it to other elements.
 
-``
+```html
 <div>
   My text here. Followed by Lorem Ipsum. <ph-txt words=30>
 </div>
 ```
 
-```
+```html
 <div ph-txt paragraphs=2 sentences=9>
 </div>
 ```
@@ -180,7 +181,7 @@ You can also get smaller amounts, and add it to other elements.
 
 Use `repeat=` to repeat the contents of an element. The new elements are created with jQuery's `.clone()` method.
 
-```
+```html
 <div repeat=3>
   <h3>Hey there!</h3>
   <div>This is my block content.</div>
@@ -188,7 +189,7 @@ Use `repeat=` to repeat the contents of an element. The new elements are created
 ```
 This results in the following markup in-browser:
 
-```
+```html
 <div repeat="3" class="ng-scope">
   <h3>Hey there!</h3>
   <div>This is my block content.</div>

--- a/app/scripts/angular/directives/directives.js
+++ b/app/scripts/angular/directives/directives.js
@@ -102,7 +102,7 @@ angular.module('ngTractor')
         var canvas;
         var bgColor = (attr.bgColor) ? attr.bgColor : "#CCCCCC";
         var txtColor = (attr.txtColor) ? attr.txtColor : "#959595";
-        var text = (attr.text) ? attr.text : attr.dimensions;
+        var text = (attr.text) ? attr.text : scope.dimensions;
         console.log(text);
 
 


### PR DESCRIPTION
This pull request adds some really basic documentation for ph-img, ph-txt, and repeat. I also added sections for tab & pane, but not docs (yet). This is how they work, as best I can tell from the code, but I might have missed some subtleties.

-Evan
